### PR TITLE
chore(ss): resource consumption improve + interlock

### DIFF
--- a/SpaceShip/src/SpaceShip.Domain/Entities/Resource.cs
+++ b/SpaceShip/src/SpaceShip.Domain/Entities/Resource.cs
@@ -71,14 +71,25 @@ public class Resource : BaseEntity
     /// <summary>
     /// Resource type required for this resource repair.
     /// </summary>
-    public (ResourceType? ResourceType, int Amount) SpareResourceType => (ResourceType, StateCriticality) switch
+    public (ResourceType? ResourceType, int Amount) SpareResourceType
     {
-        (ResourceType.Hull, EventLevel.Low) => (ResourceType.ScrapMetal, 1),
-        (ResourceType.Hull, EventLevel.Medium) => (ResourceType.ScrapMetal, 2),
-        (ResourceType.Hull, EventLevel.High) => (ResourceType.ScrapMetal, 3),
-        (ResourceType.Engine, _) => (ResourceType.ScrapMetal, 1),
-        (ResourceType.ScrapMetal, _) => (null, 0),
-        (ResourceType.Fuel, _) => (null, 0),
-        _ => (null, 0)
-    };
+        get
+        {
+            if (State != ResourceState.Fail)
+            {
+                return (null, 0); // No needs to repair.
+            }
+
+            return (ResourceType, StateCriticality) switch
+            {
+                (ResourceType.Hull, EventLevel.Low) => (ResourceType.ScrapMetal, 1),
+                (ResourceType.Hull, EventLevel.Medium) => (ResourceType.ScrapMetal, 2),
+                (ResourceType.Hull, EventLevel.High) => (ResourceType.ScrapMetal, 3),
+                (ResourceType.Engine, _) => (ResourceType.ScrapMetal, 1),
+                (ResourceType.ScrapMetal, _) => (null, 0),
+                (ResourceType.Fuel, _) => (null, 0),
+                _ => (null, 0)
+            };
+        }
+    }
 }

--- a/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/EventConsumer.cs
+++ b/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/EventConsumer.cs
@@ -76,6 +76,7 @@ public abstract class EventConsumer : IHostedService
 
     #endregion
 
+    /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         CreateQueue(QueueName);
@@ -90,7 +91,7 @@ public abstract class EventConsumer : IHostedService
 
             _logger.LogInformation("{consumer} received new message: {message}", ConsumerName, message);
 
-            await HandleMessageAsync(message, ea.RoutingKey);
+            await HandleMessageAsync(message, cancellationToken, routingKey: ea.RoutingKey);
         };
 
         try
@@ -106,6 +107,7 @@ public abstract class EventConsumer : IHostedService
         }
     }
 
+    /// <inheritdoc/>
     public Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("{consumer} stopping", ConsumerName);
@@ -116,7 +118,13 @@ public abstract class EventConsumer : IHostedService
         return Task.CompletedTask;
     }
 
-    protected abstract Task HandleMessageAsync(string message, string routingKey = "");
+    /// <summary>
+    /// Processing message method.
+    /// </summary>
+    /// <param name="message">Message body.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="routingKey">RabbitMQ routing, normally contains processing entity identifier.</param>
+    protected abstract Task HandleMessageAsync(string message, CancellationToken cancellationToken, string routingKey = "");
 
     private void CreateQueue(string queueName)
     {

--- a/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/StepEventConsumer.cs
+++ b/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/StepEventConsumer.cs
@@ -36,7 +36,7 @@ public class StepEventConsumer : EventConsumer
     }
 
     /// <inheritdoc/>
-    protected override async Task HandleMessageAsync(string message, string routingKey = "")
+    protected override async Task HandleMessageAsync(string message, CancellationToken cancellationToken, string routingKey = "")
     {
         StepMessageDTO? stepMessage;
 
@@ -63,7 +63,8 @@ public class StepEventConsumer : EventConsumer
             using IServiceScope scope = _scopeServiceFactory.CreateScope();
             IShipService shipService = scope.ServiceProvider.GetRequiredService<IShipService>();
 
-            ShipDTO ship = shipService.ProcessNewDay(stepMessage.ShipId);
+            ShipDTO ship = await shipService.ProcessNewDay(stepMessage.ShipId, cancellationToken);
+
             await _notificationsProvider.SendAsync(stepMessage.ShipId, ship);
         }
         catch (Exception e)

--- a/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/TroubleEventConsumer.cs
+++ b/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/TroubleEventConsumer.cs
@@ -41,7 +41,8 @@ public class TroubleEventConsumer : EventConsumer
         _logger = logger;
     }
 
-    protected override async Task HandleMessageAsync(string message, string routingKey)
+    /// <inheritdoc/>
+    protected override async Task HandleMessageAsync(string message, CancellationToken cancellationToken, string routingKey = "")
     {
         TroubleMessageDTO? troubleMessage;
 
@@ -68,7 +69,8 @@ public class TroubleEventConsumer : EventConsumer
             using IServiceScope scope = _scopeServiceFactory.CreateScope();
             IShipService shipService = scope.ServiceProvider.GetRequiredService<IShipService>();
 
-            ShipDTO ship = await shipService.ApplyFailureAsync(trouble);
+            ShipDTO ship = await shipService.ApplyFailureAsync(trouble, cancellationToken);
+
             await _notificationsProvider.SendAsync(trouble.ShipId, ship);
         }
         catch (Exception e)

--- a/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/TroubleEventConsumer.cs
+++ b/SpaceShip/src/SpaceShip.Service.EventsProvider/Services/TroubleEventConsumer.cs
@@ -68,7 +68,7 @@ public class TroubleEventConsumer : EventConsumer
             using IServiceScope scope = _scopeServiceFactory.CreateScope();
             IShipService shipService = scope.ServiceProvider.GetRequiredService<IShipService>();
 
-            ShipDTO ship = shipService.ApplyFailure(trouble);
+            ShipDTO ship = await shipService.ApplyFailureAsync(trouble);
             await _notificationsProvider.SendAsync(trouble.ShipId, ship);
         }
         catch (Exception e)

--- a/SpaceShip/src/SpaceShip.Service/Interfaces/IShipService.cs
+++ b/SpaceShip/src/SpaceShip.Service/Interfaces/IShipService.cs
@@ -21,12 +21,12 @@ public interface IShipService
     /// <summary>
     /// Process new day on board the SpaceShip with <paramref name="shipId"/>.
     /// </summary>
-    ShipDTO ProcessNewDay(Guid shipId);
+    Task<ShipDTO> ProcessNewDay(Guid shipId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Process trouble message for SpaceShip.
     /// </summary>
-    Task<ShipDTO> ApplyFailureAsync(Trouble trouble);
+    Task<ShipDTO> ApplyFailureAsync(Trouble trouble, CancellationToken cancellationToken);
 
     /// <summary>
     /// Delete the SpaceShip with <paramref name="shipId"/>.

--- a/SpaceShip/src/SpaceShip.Service/Interfaces/IShipService.cs
+++ b/SpaceShip/src/SpaceShip.Service/Interfaces/IShipService.cs
@@ -26,7 +26,7 @@ public interface IShipService
     /// <summary>
     /// Process trouble message for SpaceShip.
     /// </summary>
-    ShipDTO ApplyFailure(Trouble trouble);
+    Task<ShipDTO> ApplyFailureAsync(Trouble trouble);
 
     /// <summary>
     /// Delete the SpaceShip with <paramref name="shipId"/>.

--- a/SpaceShip/src/SpaceShip.Service/Services/ResourceService.cs
+++ b/SpaceShip/src/SpaceShip.Service/Services/ResourceService.cs
@@ -79,16 +79,11 @@ namespace SpaceShip.Service.Services
         /// <inheritdoc/>
         public (ResourceType? ResourceType, int Amount) GetSpareResourceRequirement(Resource resource)
         {
-            if (resource.State != ResourceState.Fail)
-            {
-                _logger.LogInformation(
-                    "No needs to repair. Resource {resourceName} of type {resourceType} is in {resourceState} state.",
-                    resource.Name,
-                    resource.ResourceType,
-                    resource.State);
-
-                return (null, 0);
-            }
+            _logger.LogInformation(
+                "Calculate spare parts to repair resource {resourceName} of type {resourceType} in {resourceState} state.",
+                resource.Name,
+                resource.ResourceType,
+                resource.State);
 
             return resource.SpareResourceType;
         }

--- a/SpaceShip/src/SpaceShip.Service/Services/ShipService.cs
+++ b/SpaceShip/src/SpaceShip.Service/Services/ShipService.cs
@@ -104,7 +104,13 @@ public class ShipService : IShipService
         Resource component = ship.Resources.Where(x => x.ResourceType == trouble.Resource).OrderBy(x => x.State).First();
         if (component is not null)
         {
-            _resourceService.UpdateResourceState(component, ResourceState.Fail, trouble.Level);
+            var troubleLevel = component.StateCriticality ?? trouble.Level;
+            troubleLevel = troubleLevel > trouble.Level ? troubleLevel : trouble.Level;
+
+            _resourceService.UpdateResourceState(
+                component,
+                ResourceState.Fail,
+                troubleLevel);
         }
 
         UpdateRepositoryShip(ship);


### PR DESCRIPTION
Добавил блокировку при обновлении корабля из пакета Shared.Utilities. При этом немного доработал асинхронные вызовы и проброс cancellationToken.
```
    private async Task UpdateRepositoryShip(Ship ship)
    {
        _logger.LogInformation("Saving ship [{id}] to repository", ship.Id);

        using (await _shipLock.LockAsync(ship.Id, _logger, CancellationToken.None))
        {
            _shipRepository.Update(ship, saveChanges: true);
        }

        _logger.LogInformation("Ship [{id}] to repository successfully saved", ship.Id);
    }
```

Перенес проверку состояния ресурса при выдаче требований для ремонта.
Добавил проверку уровня новой проблемы, при наличии действующей проблемы на корабле.


